### PR TITLE
docs: add VDP web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Implementation of paper - [YOLOv7: Trainable bag-of-freebies sets new state-of-t
 ## Web Demo
 
 - Integrated into [Huggingface Spaces 🤗](https://huggingface.co/spaces/akhaliq/yolov7) using [Gradio](https://github.com/gradio-app/gradio). Try out the Web Demo [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/akhaliq/yolov7)
+- Integrated into [VDP](https://github.com/instill-ai/vdp) using [Streamlit](https://streamlit.io/). Try out the Web Demo [![VDP Demo](https://img.shields.io/badge/VDP-YOLOv4%20vs.%20YOLOv7-blue)](https://demo.instill.tech/yolov4-vs-yolov7)
 
 ## Performance 
 


### PR DESCRIPTION
This VDP demo provides an online interactive demo to compare qualitative inference results between YOLOv4 and YOLOv7.