### PR TITLE
Dynamic batchsize export support for ONNX and TensorRT

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ $ docker cp yolov7-tiny.onnx 898c16f38c99:/workspace/tensorrt/bin
 $ # in container now
 $ cd /workspace/tensorrt/bin
 $ # convert onnx to tensorrt with min batch size 1, opt batch size 8 and max batch size 16
-$ ./trtexec --onnx=yolov7-tiny.onnx --minShapes=input:1x3x640x640 --optShapes=input:8x3x640x640 --maxShapes=input:16x3x640x640 --fp16 --saveEngine=yolov7-tiny.engine
+$ ./trtexec --onnx=yolov7-tiny.onnx --minShapes=input:1x3x640x640 --optShapes=input:8x3x640x640 --maxShapes=input:16x3x640x640 --fp16 --workspace=4096 --saveEngine=yolov7-tiny.engine
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Tested with: Python 3.7.13 and Pytorch 1.12.0+cu113
 
 - `--include-grid`: Add Detect layer
 - `--include-nms`: Add EfficientNMS plugin
+- `--include-nms-score-thresh`: NMS plugin threshold for score
+- `--include-nms-nms-thresh`: NMS plugin threshold for NMS IoU
+- `--include-nms-detections-per-image`: NMS plugin threshold for maximum amount of resulting objects per image
 - `--dynamic-batch`: Make first input dimension dynamic for dynamic batch support
 - `--dynamic-shape`: Make third and fourth input dimension dynamic for dynamic width and height
 - `--onnx-simplify` Run [onnx-simplifier](https://github.com/daquexian/onnx-simplifier)

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Tested with: Python 3.7.13 and Pytorch 1.12.0+cu113
 - `--dynamic-shape`: Make third and fourth input dimension dynamic for dynamic width and height
 - `--onnx-simplify` Run [onnx-simplifier](https://github.com/daquexian/onnx-simplifier)
 
-yolov7-tiny to ONNX with grid, nms and dynamic batchsize:
+yolov7-tiny to ONNX with dynamic batchsize, grid and nms(score-thresh=0.2, nms-thresh=0.5, detections-per-image=500):
 ```shell
 wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-tiny.pt
-python export.py --weights yolov7-tiny.pt --dynamic-batch --include-grid --include-nms --onnx-simplify
+!python export.py --weights yolov7-tiny.pt --onnx-simplify --dynamic-batch --include-grid --include-nms --include-nms-score-thresh=0.2 --include-nms-nms-thresh=0.5 --include-nms-detections-per-image=500
 ```
 
 ### ONNX to TensorRT

--- a/README.md
+++ b/README.md
@@ -153,14 +153,22 @@ python detect.py --weights yolov7.pt --conf 0.25 --img-size 640 --source inferen
 
 
 ## Export
-Tested with: Python 3.7.13 and Pytorch 1.12.0+cu113 
-Pytorch to ONNX, use `--include-nms` flag for the end-to-end ONNX model with `EfficientNMS`.
+### Pytorch to ONNX
+Tested with: Python 3.7.13 and Pytorch 1.12.0+cu113
+
+- `--include-grid`: Add Detect layer
+- `--include-nms`: Add EfficientNMS plugin
+- `--dynamic-batch`: Make first input dimension dynamic for dynamic batch support
+- `--dynamic-shape`: Make third and fourth input dimension dynamic for dynamic width and height
+- `--onnx-simplify` Run [onnx-simplifier](https://github.com/daquexian/onnx-simplifier)
+
+yolov7-tiny to ONNX with grid, nms and dynamic batchsize:
 ```shell
 wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-tiny.pt
-python export.py --weights yolov7-tiny.pt --include-grid --include-nms
+python export.py --weights yolov7-tiny.pt --dynamic-batch --include-grid --include-nms --onnx-simplify
 ```
 
-ONNX to TensorRT
+### ONNX to TensorRT
 ```shell
 git clone https://github.com/Linaom1214/tensorrt-python.git
 cd tensorrt-python

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Tested with: Python 3.7.13 and Pytorch 1.12.0+cu113
 Pytorch to ONNX, use `--include-nms` flag for the end-to-end ONNX model with `EfficientNMS`.
 ```shell
 wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-tiny.pt
-python export.py --weights yolov7-tiny.pt --grid --include-nms
+python export.py --weights yolov7-tiny.pt --include-grid --include-nms
 ```
 
 ONNX to TensorRT

--- a/README.md
+++ b/README.md
@@ -171,11 +171,15 @@ wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-tiny.pt
 !python export.py --weights yolov7-tiny.pt --onnx-simplify --dynamic-batch --include-grid --include-nms --include-nms-score-thresh=0.2 --include-nms-nms-thresh=0.5 --include-nms-detections-per-image=500
 ```
 
-### ONNX to TensorRT
+### ONNX to TensorRT with docker
 ```shell
-git clone https://github.com/Linaom1214/tensorrt-python.git
-cd tensorrt-python
-python export.py -o yolov7-tiny.onnx -e yolov7-tiny-nms.trt -p fp16
+$ docker run -it --rm --gpus=all nvcr.io/nvidia/tensorrt:22.04-py3
+$ # from new shell copy onnx to container
+$ docker cp yolov7-tiny.onnx 898c16f38c99:/workspace/tensorrt/bin
+$ # in container now
+$ cd /workspace/tensorrt/bin
+$ # convert onnx to tensorrt with min batch size 1, opt batch size 8 and max batch size 16
+$ ./trtexec --onnx=yolov7-tiny.onnx --minShapes=input:1x3x640x640 --optShapes=input:8x3x640x640 --maxShapes=input:16x3x640x640 --fp16 --saveEngine=yolov7-tiny.engine
 ```
 
 ## Citation

--- a/export.py
+++ b/export.py
@@ -21,10 +21,10 @@ if __name__ == '__main__':
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--dynamic-batch', action='store_true', help='dynamic ONNX batchsize')
     parser.add_argument('--dynamic-shape', action='store_true', help='dynamic ONNX input width and height')
-    parser.add_argument('--grid', action='store_true', help='export Detect() layer grid')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
-    parser.add_argument('--simplify', action='store_true', help='simplify onnx model')
+    parser.add_argument('--include-grid', action='store_true', help='export Detect() layer grid')
     parser.add_argument('--include-nms', action='store_true', help='export end2end onnx')
+    parser.add_argument('--onnx-simplify', action='store_true', help='simplify onnx model')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
     print(opt)
@@ -53,7 +53,7 @@ if __name__ == '__main__':
                 m.act = SiLU()
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
-    model.model[-1].export = not opt.grid  # set Detect() layer grid export
+    model.model[-1].export = not opt.include_grid  # set Detect() layer grid export
     y = model(img)  # dry run
     if opt.include_nms:
         model.model[-1].include_nms = True
@@ -102,7 +102,7 @@ if __name__ == '__main__':
         #     meta.key, meta.value = k, str(v)
         # onnx.save(onnx_model, f)
 
-        if opt.simplify:
+        if opt.onnx_simplify:
             try:
                 import onnxsim
 

--- a/export.py
+++ b/export.py
@@ -23,7 +23,10 @@ if __name__ == '__main__':
     parser.add_argument('--dynamic-shape', action='store_true', help='dynamic ONNX input width and height')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--include-grid', action='store_true', help='export Detect() layer grid')
-    parser.add_argument('--include-nms', action='store_true', help='export end2end onnx')
+    parser.add_argument('--include-nms', action='store_true', help='export nms plugin')
+    parser.add_argument('--include-nms-score-thresh', default=0.25, type=float, help='export nms plugin score threshold, default 0.25')
+    parser.add_argument('--include-nms-nms-thresh', default=0.45, type=float, help='export nms plugin nms threshold, default 0.45')
+    parser.add_argument('--include-nms-detections-per-image', default=100, type=int, help='export nms plugin max detections per image, default 100')
     parser.add_argument('--onnx-simplify', action='store_true', help='simplify onnx model')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
@@ -118,7 +121,7 @@ if __name__ == '__main__':
         if opt.include_nms:
             print('Registering NMS plugin for ONNX...')
             mo = RegisterNMS(f)
-            mo.register_nms()
+            mo.register_nms(score_thresh=opt.include_nms_score_thresh, nms_thresh=opt.include_nms_nms_thresh, detections_per_img=opt.include_nms_detections_per_img)
             mo.save(f)
 
     except Exception as e:

--- a/export.py
+++ b/export.py
@@ -86,7 +86,8 @@ if __name__ == '__main__':
                 dynamic_axes['input'][3] = 'width'
                 dynamic_axes['output'][2] = 'y'
                 dynamic_axes['output'][3] = 'x'
-        torch.onnx.export(model, img, f, verbose=False, opset_version=12, input_names=['images'],
+        torch.onnx.export(model, img, f, verbose=False, opset_version=12,
+                          input_names=['input'],
                           output_names=['classes', 'boxes'] if y is None else ['output'],
                           dynamic_axes=dynamic_axes)
 

--- a/export.py
+++ b/export.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
         if opt.include_nms:
             print('Registering NMS plugin for ONNX...')
             mo = RegisterNMS(f)
-            mo.register_nms(score_thresh=opt.include_nms_score_thresh, nms_thresh=opt.include_nms_nms_thresh, detections_per_img=opt.include_nms_detections_per_img)
+            mo.register_nms(score_thresh=opt.include_nms_score_thresh, nms_thresh=opt.include_nms_nms_thresh, detections_per_img=opt.include_nms_detections_per_image)
             mo.save(f)
 
     except Exception as e:


### PR DESCRIPTION
This PR enables the "--dynamic-batch" option for ONNX export. This will set the input dimension of the network to [batch,3,640,640] and allows arbitrary batch sizes to be run with the model.


Working Colab Demo:
https://colab.research.google.com/drive/1vH5wwUvWoGrJ989EzNcESs1tFxW6i1K7?usp=sharing

Netron Info:
![image](https://user-images.githubusercontent.com/25586333/180483331-d072fb63-adcc-4ca5-803c-52e8876ead36.png)

Works with NMS plugin:
![image](https://user-images.githubusercontent.com/25586333/180483376-638bf6ca-487d-41d6-ae6d-f4b8b7cfdb42.png)

TensorRT now enables optimization profiles for arbitrary batch sizes:
![image](https://user-images.githubusercontent.com/25586333/180483157-e359d28a-08ba-4374-ba63-fe71d9d7fa91.png)

1900 FPS on RTX 3090 for yolov7-tiny (batch size 16 in this screenshot)
![image](https://user-images.githubusercontent.com/25586333/180484035-2475aad8-0481-4d3e-bb47-462aecfb3a99.png)

Also a few additional refactoring changes - e.g. to set score_thresh and detections_per_image for NMS plugin