### PR TITLE
non-max-suppression function fixed for one class model conf.

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -645,7 +645,11 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
             continue
 
         # Compute conf
-        x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
+        if nc == 1:
+            x[:, 5:] = x[:, 4:5] # for models with one class, cls_loss is 0 and cls_conf is always 0.5,
+                                 # so there is no need to multiplicate.
+        else:
+            x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
 
         # Box (center x, center y, width, height) to (x1, y1, x2, y2)
         box = xywh2xyxy(x[:, :4])


### PR DESCRIPTION
For models with only one class, computation of conf in non_max_suppression function has some problems. Due to [#92](https://github.com/WongKinYiu/yolov7/issues/92#issue-1301120292) some people has this problem with the code. Value of conf when using `detect.py` always vary between 0 and 0.5.

For this models, cls_loss wont be computed and value of cls_conf always equals to approximately 0.5. So computation of conf in this situation with the formula `conf = obj_conf * cls_conf` will always give results between 0 and 0.5.

I add an if statement for this situation. If model had only one class, function won't use above mentioned formula and use exactly obj_conf as conf of model output.