### PR TITLE
Fix onnx export in torch==1.10.0

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -56,7 +56,7 @@ class Detect(nn.Module):
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:
                     xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
+                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
                     y = torch.cat((xy, wh, y[..., 4:]), -1)
                 z.append(y.view(bs, -1, self.no))
 


### PR DESCRIPTION
See also in https://github.com/WongKinYiu/yolov7/pull/300.
Export onnx for onnxruntime and tensorrt failure can be reproduced at nvcr.io/nvidia/pytorch:21.08-py3.
It seems like anchor_grid can not broadcast well from buffer.