### PR TITLE
fix `tensor.detach` error of pose estimation

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -439,8 +439,8 @@ def output_to_keypoint(output):
     for i, o in enumerate(output):
         kpts = o[:,6:]
         o = o[:,:6]
-        for index, (*box, conf, cls) in enumerate(o.cpu().numpy()):
-            targets.append([i, cls, *list(*xyxy2xywh(np.array(box)[None])), conf, *list(kpts.cpu().numpy()[index])])
+        for index, (*box, conf, cls) in enumerate(o.detach().cpu().numpy()):
+            targets.append([i, cls, *list(*xyxy2xywh(np.array(box)[None])), conf, *list(kpts.detach().cpu().numpy()[index])])
     return np.array(targets)
 
 


### PR DESCRIPTION
The error `RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.` of `kepoint.ipynb` fixed.