### PR TITLE
Add grid concat and fuse such operators

### DIFF
--- a/export.py
+++ b/export.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
                 else:
                     output_names = ['output']
             else:
-                model.concat = True
+                model.model[-1].concat = True
 
         torch.onnx.export(model, img, f, verbose=False, opset_version=12, input_names=['images'],
                           output_names=output_names,

--- a/export.py
+++ b/export.py
@@ -105,15 +105,18 @@ if __name__ == '__main__':
                     'output': {0: 'batch'},
                 }
             dynamic_axes.update(output_axes)
-        if opt.grid and opt.end2end:
-            print('\nStarting export end2end onnx model for %s...' % 'TensorRT' if opt.max_wh is None else 'onnxruntime')
-            model = End2End(model,opt.topk_all,opt.iou_thres,opt.conf_thres,opt.max_wh,device)
-            if opt.end2end and opt.max_wh is None:
-                output_names = ['num_dets', 'det_boxes', 'det_scores', 'det_classes']
-                shapes = [opt.batch_size, 1, opt.batch_size, opt.topk_all, 4,
-                          opt.batch_size, opt.topk_all, opt.batch_size, opt.topk_all]
+        if opt.grid:
+            if opt.end2end:
+                print('\nStarting export end2end onnx model for %s...' % 'TensorRT' if opt.max_wh is None else 'onnxruntime')
+                model = End2End(model,opt.topk_all,opt.iou_thres,opt.conf_thres,opt.max_wh,device)
+                if opt.end2end and opt.max_wh is None:
+                    output_names = ['num_dets', 'det_boxes', 'det_scores', 'det_classes']
+                    shapes = [opt.batch_size, 1, opt.batch_size, opt.topk_all, 4,
+                              opt.batch_size, opt.topk_all, opt.batch_size, opt.topk_all]
+                else:
+                    output_names = ['output']
             else:
-                output_names = ['output']
+                model.concat = True
 
         torch.onnx.export(model, img, f, verbose=False, opset_version=12, input_names=['images'],
                           output_names=output_names,

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -56,12 +56,9 @@ class Detect(nn.Module):
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:
-                    # xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    # wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
-                    # y = torch.cat((xy, wh, y[..., 4:]), -1)
                     xy, wh, conf = y.split((2, 2, self.nc + 1), 4)  # y.tensor_split((2, 4, 5), 4)  # torch 1.8.0
                     xy = xy * (2. * self.stride[i]) + (self.stride[i] * (self.grid[i] - 0.5))  # new xy
-                    wh = wh ** 2 * (4 * self.anchor_grid[i].data) # new wh
+                    wh = wh ** 2 * (4 * self.anchor_grid[i].data)  # new wh
                     y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, -1, self.no))
 
@@ -157,9 +154,10 @@ class IDetect(nn.Module):
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:
-                    xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
-                    y = torch.cat((xy, wh, y[..., 4:]), -1)
+                    xy, wh, conf = y.split((2, 2, self.nc + 1), 4)  # y.tensor_split((2, 4, 5), 4)  # torch 1.8.0
+                    xy = xy * (2. * self.stride[i]) + (self.stride[i] * (self.grid[i] - 0.5))  # new xy
+                    wh = wh ** 2 * (4 * self.anchor_grid[i].data)  # new wh
+                    y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, -1, self.no))
 
         if self.training:
@@ -351,9 +349,10 @@ class IAuxDetect(nn.Module):
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:
-                    xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
-                    y = torch.cat((xy, wh, y[..., 4:]), -1)
+                    xy, wh, conf = y.split((2, 2, self.nc + 1), 4)  # y.tensor_split((2, 4, 5), 4)  # torch 1.8.0
+                    xy = xy * (2. * self.stride[i]) + (self.stride[i] * (self.grid[i] - 0.5))  # new xy
+                    wh = wh ** 2 * (4 * self.anchor_grid[i].data)  # new wh
+                    y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, -1, self.no))
 
         return x if self.training else (torch.cat(z, 1), x[:self.nl])

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -24,7 +24,8 @@ class Detect(nn.Module):
     stride = None  # strides computed during build
     export = False  # onnx export
     end2end = False
-    include_nms = False 
+    include_nms = False
+    concat = False
 
     def __init__(self, nc=80, anchors=(), ch=()):  # detection layer
         super(Detect, self).__init__()
@@ -55,9 +56,13 @@ class Detect(nn.Module):
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:
-                    xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
-                    y = torch.cat((xy, wh, y[..., 4:]), -1)
+                    # xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
+                    # wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].data  # wh
+                    # y = torch.cat((xy, wh, y[..., 4:]), -1)
+                    xy, wh, conf = y.split((2, 2, self.nc + 1), 4)  # y.tensor_split((2, 4, 5), 4)  # torch 1.8.0
+                    xy = xy * (2. * self.stride[i]) + (self.stride[i] * (self.grid[i] - 0.5))  # new xy
+                    wh = wh ** 2 * (4 * self.anchor_grid[i].data) # new wh
+                    y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, -1, self.no))
 
         if self.training:
@@ -67,6 +72,8 @@ class Detect(nn.Module):
         elif self.include_nms:
             z = self.convert(z)
             out = (z, )
+        elif self.concat:
+            out = torch.cat(z, 1)
         else:
             out = (torch.cat(z, 1), x)
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -98,7 +98,8 @@ class IDetect(nn.Module):
     stride = None  # strides computed during build
     export = False  # onnx export
     end2end = False
-    include_nms = False 
+    include_nms = False
+    concat = False
 
     def __init__(self, nc=80, anchors=(), ch=()):  # detection layer
         super(IDetect, self).__init__()
@@ -312,6 +313,7 @@ class IAuxDetect(nn.Module):
     export = False  # onnx export
     end2end = False
     include_nms = False
+    concat = False
 
     def __init__(self, nc=80, anchors=(), ch=()):  # detection layer
         super(IAuxDetect, self).__init__()

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -167,6 +167,8 @@ class IDetect(nn.Module):
         elif self.include_nms:
             z = self.convert(z)
             out = (z, )
+        elif self.concat:
+            out = torch.cat(z, 1)            
         else:
             out = (torch.cat(z, 1), x)
 
@@ -387,6 +389,8 @@ class IAuxDetect(nn.Module):
         elif self.include_nms:
             z = self.convert(z)
             out = (z, )
+        elif self.concat:
+            out = torch.cat(z, 1)            
         else:
             out = (torch.cat(z, 1), x)
 


### PR DESCRIPTION
Now we can export concat all anchors outputs in flag `--grid` !
If we use `--grid` only, we will export an onnx with one concat output.
If we use `--grid` and `--end2end`, we will export an onnx with nms.
And now the anchor generate process is simplied as the picture shown!
![yolov7-before-now](https://user-images.githubusercontent.com/92794867/182186704-c171ab38-357d-4f2f-9431-e3a99e693e56.png)
It will speed up in onnxruntime and tensorrt backends!