### PR TITLE
fix a model inference problem on cpu

### DIFF
--- a/tools/keypoint.ipynb
+++ b/tools/keypoint.ipynb
@@ -27,7 +27,10 @@
     "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "weigths = torch.load('yolov7-w6-pose.pt', map_location=device)\n",
     "model = weigths['model']\n",
-    "_ = model.float().eval() "
+    "_ = model.float().eval()\n",
+    "\n",
+    "if torch.cuda.is_available():\n",
+    "    model.half().to(device)"
    ]
   },
   {
@@ -42,8 +45,9 @@
     "image_ = image.copy()\n",
     "image = transforms.ToTensor()(image)\n",
     "image = torch.tensor(np.array([image.numpy()]))\n",
-    "image = image.to(device)\n",
     "\n",
+    "if torch.cuda.is_available():\n",
+    "    image = image.half().to(device)   \n",
     "output, _ = model(image)"
    ]
   },
@@ -116,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/tools/keypoint.ipynb
+++ b/tools/keypoint.ipynb
@@ -25,10 +25,9 @@
    "outputs": [],
    "source": [
     "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
-    "weigths = torch.load('yolov7-w6-pose.pt')\n",
+    "weigths = torch.load('yolov7-w6-pose.pt', map_location=device)\n",
     "model = weigths['model']\n",
-    "model = model.half().to(device)\n",
-    "_ = model.eval()"
+    "_ = model.float().eval() "
    ]
   },
   {
@@ -44,7 +43,6 @@
     "image = transforms.ToTensor()(image)\n",
     "image = torch.tensor(np.array([image.numpy()]))\n",
     "image = image.to(device)\n",
-    "image = image.half()\n",
     "\n",
     "output, _ = model(image)"
    ]
@@ -118,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. I run `keypoint.ipynb` on a cpu-machine (macbook). And I got the following problem:
```
----> 2 weigths = torch.load('yolov7-w6-pose.pt')
...
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

2. So, as it suggests, I have added `map_location=torch.device(device)` option to `load` function but it turns out one of the convolutions used in the model was not designed for 'half' precision when running on cpu and I got the following error.

`RuntimeError: "slow_conv2d_cpu" not implemented for 'Half'`

3. Then, I removed `half` precision option from the notebook and added `_ = model.float().eval()` to run it on both cpu and gpu machines.
I suppose a lot of folks like me will try it on cpu for demo test.

I have tested the fixed code on both cpu and gpu in google colab and the link is here:
https://colab.research.google.com/drive/1kqdVq-n8I0EcPRA2g7YYK70rArUmy6Ai?usp=sharing