### PR TITLE
fix(utils): missing edge when resample segments

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -310,6 +310,7 @@ def segments2boxes(segments):
 def resample_segments(segments, n=1000):
     # Up-sample an (n,2) segment
     for i, s in enumerate(segments):
+        s = np.concatenate((s, s[0:1, :]), axis=0)
         x = np.linspace(0, len(s) - 1, n)
         xp = np.arange(len(s))
         segments[i] = np.concatenate([np.interp(x, xp, s[:, i]) for i in range(2)]).reshape(2, -1).T  # segment xy


### PR DESCRIPTION
One small problem. When resample segments, missing an edge from the last point to the first.
Eg: https://github.com/HRan2004/Yolo-ArbV2/blob/main/data/images/debug01.png
When the polygon is cut, the missing edge will lead to the wrong position of the GT box.

I have submitted PR to yolov5. https://github.com/ultralytics/yolov5/pull/8092
The author of yolov5 tested on the segments dataset and verified that this indeed solved a bug. https://wandb.ai/glenn-jocher/test-segmentfix
