### PR TITLE
Add YOLOv7 quantization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ python ./tensorrt-python/export.py -o yolov7-tiny.onnx -e yolov7-tiny-nms.trt -p
 
 Tested with: Python 3.7.13, Pytorch 1.12.0+cu113
 
+## Quantization
+
+See [YOLOv7_quantization_act.ipynb](./tools/YOLOv7_quantization_act.ipynb)
+
+- Benchmark
+
+| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> | Model |
+| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: | :----------------: |
+| YOLOv7 |  51.2   | 50.9  |  26.84ms  |   7.44ms   |  **4.55ms**  | [ONNX](https://paddle-slim-models.bj.bcebos.com/act/yolov7.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov7_quant_onnx.tar) |
+| YOLOv7-Tiny  |  37.3   | 37.0 |  5.06ms  |   2.32ms   |  **1.68ms** | [ONNX](https://paddle-slim-models.bj.bcebos.com/act/yolov7-tiny.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov7_tiny_quant_onnx.tar) |
+
+
+
 ## Pose estimation
 
 [`code`](https://github.com/WongKinYiu/yolov7/tree/pose) [`yolov7-w6-pose.pt`](https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-w6-pose.pt)

--- a/tools/YOLOv7_quantization_act.ipynb
+++ b/tools/YOLOv7_quantization_act.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# YOLOv7 Quantization Compression Example\n",
+    "\n",
+    "This example uses [ACT](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression) from [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim) for YOLOv7 quantization.\n",
+    "The quantized model can be deployed on TensorRT.\n",
+    "\n",
+    "- Benchmark\n",
+    "\n",
+    "| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> | Model |\n",
+    "| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: | :----------------: |\n",
+    "| YOLOv7 |  51.2   | 50.9  |  26.84ms  |   7.44ms   |  **4.55ms**  | [ONNX](https://paddle-slim-models.bj.bcebos.com/act/yolov7.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov7_quant_onnx.tar) |\n",
+    "| YOLOv7-Tiny  |  37.3   | 37.0 |  5.06ms  |   2.32ms   |  **1.68ms** | [ONNX](https://paddle-slim-models.bj.bcebos.com/act/yolov7-tiny.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov7_tiny_quant_onnx.tar) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Experiment\n",
+    "\n",
+    "(1) Environment Dependencies Installation:\n",
+    "  - paddlepaddle>=2.3.2\n",
+    "  - paddleslim>=2.3.4\n",
+    "  - pycocotools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Take Ubuntu and CUDA 11.2 as an example for GPU, and other environments can be installed directly according to Paddle's official website.\n",
+    "#  https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/install/pip/linux-pip.html \n",
+    "\n",
+    "python -m pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html\n",
+    "\n",
+    "# CPU\n",
+    "#pip install paddlepaddle==2.3.2\n",
+    "\n",
+    "pip install paddleslim==2.3.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(2) Model Preparation: the YOLOv7 ONNX model (currently only exclude NMS are supported)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# export yolov7-tiny.onnx\n",
+    "!git clone https://github.com/WongKinYiu/yolov7\n",
+    "%cd yolov7\n",
+    "!wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-tiny.pt\n",
+    "!python export.py --weights yolov7-tiny.pt --grid\n",
+    "\n",
+    "# Can also directly download the exported ONNX model\n",
+    "# !wget https://paddle-slim-models.bj.bcebos.com/act/yolov7-tiny.onnx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(3) Dataset Preparation (some unlabeled pictures of real scenes):\n",
+    "\n",
+    "The directory format is as follows:\n",
+    "```\n",
+    "image_dir\n",
+    "├── 000000000139.jpg\n",
+    "├── 000000000285.jpg\n",
+    "├── ...\n",
+    "```\n",
+    "\n",
+    "We use COCO's official `val` set as the image path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_dir' = './dataset/coco/val2017/'\n",
+    "model_dir = './yolov7-tiny.onnx'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(4) Dependency Packages Import:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "os.environ['CUDA_VISIBLE_DEVICES'] = '0'\n",
+    "import paddle\n",
+    "from paddleslim.auto_compression import AutoCompression\n",
+    "\n",
+    "paddle.set_device('gpu')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(5) Definition of Data Preprocessing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _generate_scale(im, target_shape, keep_ratio=True):\n",
+    "    origin_shape = im.shape[:2]\n",
+    "    im_size_min = np.min(origin_shape)\n",
+    "    im_size_max = np.max(origin_shape)\n",
+    "    target_size_min = np.min(target_shape)\n",
+    "    target_size_max = np.max(target_shape)\n",
+    "    im_scale = float(target_size_min) / float(im_size_min)\n",
+    "    if np.round(im_scale * im_size_max) > target_size_max:\n",
+    "        im_scale = float(target_size_max) / float(im_size_max)\n",
+    "    im_scale_x = im_scale\n",
+    "    im_scale_y = im_scale\n",
+    "    return im_scale_y, im_scale_x\n",
+    "\n",
+    "def image_preprocess(img, target_shape=[640,640]):\n",
+    "    # Resize image\n",
+    "    im_scale_y, im_scale_x = _generate_scale(img, target_shape)\n",
+    "    img = cv2.resize(\n",
+    "        img,\n",
+    "        None,\n",
+    "        None,\n",
+    "        fx=im_scale_x,\n",
+    "        fy=im_scale_y,\n",
+    "        interpolation=cv2.INTER_LINEAR)\n",
+    "    # Pad\n",
+    "    im_h, im_w = img.shape[:2]\n",
+    "    h, w = target_shape[:]\n",
+    "    if h != im_h or w != im_w:\n",
+    "        canvas = np.ones((h, w, 3), dtype=np.float32)\n",
+    "        canvas *= np.array([114.0, 114.0, 114.0], dtype=np.float32)\n",
+    "        canvas[0:im_h, 0:im_w, :] = img.astype(np.float32)\n",
+    "        img = canvas\n",
+    "    img = np.transpose(img / 255, [2, 0, 1])\n",
+    "    return img.astype(np.float32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(6) Definition of Configuration for AutoCompression:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_config = {\n",
+    "    'Distillation': {\n",
+    "        'alpha': 1.0,\n",
+    "        'loss': 'soft_label'},\n",
+    "    'Quantization': {\n",
+    "        'onnx_format': True,\n",
+    "        'activation_quantize_type': 'moving_average_abs_max',\n",
+    "        'quantize_op_types': ['conv2d', 'depthwise_conv2d']},\n",
+    "    'TrainConfig': {\n",
+    "        'train_iter': 2000,\n",
+    "        'eval_iter': 1000,\n",
+    "        'learning_rate': 0.00003,\n",
+    "        'optimizer_builder': {'optimizer': {'type': 'SGD'}, 'weight_decay': 4e-05}}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(7) Auto Compression:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reader_wrapper(reader, input_name='x2paddle_images'):\n",
+    "    def gen():\n",
+    "        for data in reader:\n",
+    "            yield {input_name: data[0]}\n",
+    "    return gen\n",
+    "\n",
+    "paddle.vision.image.set_image_backend('cv2')\n",
+    "train_dataset = paddle.vision.datasets.ImageFolder(image_dir, transform=image_preprocess)\n",
+    "train_loader = paddle.io.DataLoader(train_dataset, batch_size=1, shuffle=True, drop_last=True, num_workers=0)\n",
+    "\n",
+    "ac = AutoCompression(\n",
+    "    model_dir=model_dir,\n",
+    "    train_dataloader=reader_wrapper(train_loader),\n",
+    "    save_dir='output',\n",
+    "    config=run_config,\n",
+    "    eval_callback=None)\n",
+    "ac.compress()\n",
+    "# convert to ONNX\n",
+    "ac.export_onnx()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After executing the program, output files will be generated in the output folder as shown below:\n",
+    "```shell\n",
+    "├── model.pdiparams         # Paddle predicts model weights\n",
+    "├── model.pdmodel           # Paddle prediction model file\n",
+    "├── calibration_table.txt   # Paddle calibration table after quantification\n",
+    "├── ONNX\n",
+    "│   ├── quant_model.onnx      # ONNX model after quantization\n",
+    "│   ├── calibration.cache     # TensorRT can directly load the calibration table\n",
+    "```\n",
+    "\n",
+    "- Speed Test:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trtexec --onnx=output/ONNX/quant_model.onnx --avgRuns=1000 --workspace=1024 --calib=output/ONNX/calibration.cache --int8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Python test:\n",
+    "Load `quant_model.onnx` and `calibration.cache`, you can directly use the TensorRT test script to verify. The detailed code can refer to [TensorRT deployment](/TensorRT).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/PaddlePaddle/PaddleSlim.git\n",
+    "!cd example/auto_compression/pytorch_yolo_series/TensorRT\n",
+    "python trt_eval.py --onnx_model_file=output/ONNX/quant_model.onnx \\\n",
+    "                   --calibration_file=output/ONNX/calibration.cache \\\n",
+    "                   --image_file=../images/000000570688.jpg \\\n",
+    "                   --precision_mode=int8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And you can also eval COCO mAP:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "python trt_eval.py --onnx_model_file=output/ONNX/quant_model.onnx \\\n",
+    "                   --calibration_file=output/ONNX/calibration.cache \\\n",
+    "                   --precision_mode=int8 \\\n",
+    "                   --dataset_dir=dataset/coco/ \\\n",
+    "                   --val_image_dir=val2017 \\\n",
+    "                   --val_anno_path=annotations/instances_val2017.json"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We used [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim) ACT(Auto Compression Toolkit) to quantize and compress YOLOv7, and the results on T4 are as follows:

| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> |
| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: |
| YOLOv7 |  51.2   | 50.9  |  26.84ms  |   7.44ms   |  **4.55ms**  | 
| YOLOv7-Tiny  |  37.3   | 37.0 |  5.06ms  |   2.32ms   |  **1.68ms** | 

Hope @WongKinYiu  review, thx.