### PR TITLE
fix: YOLOR -> YOLOv7 in strings and comments

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -1,4 +1,4 @@
-# YOLOR PyTorch utils
+# YOLOv7 PyTorch utils
 
 import datetime
 import logging
@@ -62,7 +62,7 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
 
 def select_device(device='', batch_size=None):
     # device = 'cpu' or '0' or '0,1,2,3'
-    s = f'YOLOR 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
+    s = f'YOLOv7 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
     cpu = device.lower() == 'cpu'
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False


### PR DESCRIPTION
Hope you're having a nice day
I suppose lots of code was copied from YOLOR repo. It needs some cleaning of comments and strings. 
Should I change some default parameters like https://github.com/WongKinYiu/yolov7/blob/44d8ab41780e24eba563b6794371f29db0902271/models/yolo.py#L818
to `yolov7.yaml` and https://github.com/WongKinYiu/yolov7/blob/44d8ab41780e24eba563b6794371f29db0902271/export.py#L21
to `yolov7.pt`?