### PR TITLE
 Fix updated image_size is not used in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -59,7 +59,7 @@ def test(data,
         imgsz = check_img_size(imgsz, s=gs)  # check img_size
         
         if trace:
-            model = TracedModel(model, device, opt.img_size)
+            model = TracedModel(model, device, imgsz)
 
     # Half
     half = device.type != 'cpu' and half_precision  # half precision only supported on CUDA


### PR DESCRIPTION
This fixes #738 which happens if you run ```test.py``` with an image_size that is not a multiple of 32 resulting in ```RuntimeError: Sizes of tensors must match except in dimension 1.``` because the updated ```imgsz``` is not used.
