### PR TITLE
Add device argument to hubconf

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -19,7 +19,7 @@ check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('pycocot
 set_logging()
 
 
-def create(name, pretrained, channels, classes, autoshape):
+def create(name, pretrained, channels, classes, autoshape, device=None):
     """Creates a specified model
 
     Arguments:
@@ -27,6 +27,7 @@ def create(name, pretrained, channels, classes, autoshape):
         pretrained (bool): load pretrained weights into the model
         channels (int): number of input channels
         classes (int): number of model classes
+        device (torch.device): the device on which to load the model, if none, cuda:0 will be chosen if available, else cpu
 
     Returns:
         pytorch model
@@ -46,7 +47,8 @@ def create(name, pretrained, channels, classes, autoshape):
                 model.names = ckpt['model'].names  # set class names attribute
             if autoshape:
                 model = model.autoshape()  # for file/URI/PIL/cv2/np inputs and NMS
-        device = select_device('0' if torch.cuda.is_available() else 'cpu')  # default to GPU if available
+        if device is None:
+            device = select_device('0' if torch.cuda.is_available() else 'cpu')  # default to GPU if available
         return model.to(device)
 
     except Exception as e:
@@ -54,7 +56,7 @@ def create(name, pretrained, channels, classes, autoshape):
         raise Exception(s) from e
 
 
-def custom(path_or_model='path/to/model.pt', autoshape=True):
+def custom(path_or_model='path/to/model.pt', autoshape=True, device=None):
     """custom mode
 
     Arguments (3 options):
@@ -74,12 +76,13 @@ def custom(path_or_model='path/to/model.pt', autoshape=True):
     hub_model.names = model.names  # class names
     if autoshape:
         hub_model = hub_model.autoshape()  # for file/URI/PIL/cv2/np inputs and NMS
-    device = select_device('0' if torch.cuda.is_available() else 'cpu')  # default to GPU if available
+    if device is None:
+        device = select_device('0' if torch.cuda.is_available() else 'cpu')  # default to GPU if available
     return hub_model.to(device)
 
 
-def yolov7(pretrained=True, channels=3, classes=80, autoshape=True):
-    return create('yolov7', pretrained, channels, classes, autoshape)
+def yolov7(pretrained=True, channels=3, classes=80, autoshape=True, device=None):
+    return create('yolov7', pretrained, channels, classes, autoshape, device=device)
 
 
 if __name__ == '__main__':

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -62,7 +62,7 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
 
 def select_device(device='', batch_size=None):
     # device = 'cpu' or '0' or '0,1,2,3'
-    s = f'YOLOR 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
+    s = f'YOLOv7 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
     cpu = device.lower() == 'cpu'
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False


### PR DESCRIPTION
Current behaviour:
When loading a model from torchhub, models are loaded onto the GPU with index 0 by default. There is no option to change this

New behaviour:
There is an argument which enables users to specify a device on which to load the model. The default behaviour is unchanged

Other:
Whilst not technically part of this work, the logging statement reads YOLOR when a model is loaded, which is confusing. I have updated this to read 'Yolov7'