### PR TITLE
Updated segmentation dataloader to work with >255 instances

### DIFF
--- a/seg/utils/segment/dataloaders.py
+++ b/seg/utils/segment/dataloaders.py
@@ -308,7 +308,8 @@ def polygons2masks(img_size, polygons, color, downsample_ratio=1):
 
 def polygons2masks_overlap(img_size, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
-    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), dtype=np.uint8)
+    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio),
+            dtype=np.int32 if len(segments) > 255 else np.uint8)
     areas = []
     ms = []
     for si in range(len(segments)):


### PR DESCRIPTION
See ultralytics/yolov5/issues/9461 and ultralytics/yolov5/pull/9493

This solves a type error that occurs when using datasets with >255 instances in an image.