### PR TITLE
Update dataloaders.py

### DIFF
--- a/seg/utils/segment/dataloaders.py
+++ b/seg/utils/segment/dataloaders.py
@@ -149,7 +149,6 @@ class LoadImagesAndLabelsAndMasks(LoadImagesAndLabels):  # for training/testing
                     scale=hyp["scale"],
                     shear=hyp["shear"],
                     perspective=hyp["perspective"],
-                    return_seg=True,
                 )
 
         nl = len(labels)  # number of labels


### PR DESCRIPTION
random_perspective( ) function does not accept  return_seg=True  argument. On turning mosaic off while training, it would give an error stating the same.