### PR TITLE
Update datasets.py

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -315,7 +315,10 @@ class LoadStreams:  # multiple IP or RTSP cameras
                 success, im = cap.retrieve()
                 self.imgs[index] = im if success else self.imgs[index] * 0
                 n = 0
-            time.sleep(1 / self.fps)  # wait time
+            if self.fps != 0:
+                time.sleep(1 / self.fps)  # wait time
+            else:
+                time.sleep(0.2)   # in rtsp situation self.fps may be zero. to avoid div by zero, take constant sleep.
 
     def __iter__(self):
         self.count = -1


### PR DESCRIPTION
Same as mentioned in
https://github.com/RizwanMunawar/yolov7-object-tracking/blob/main/utils/datasets.py When using an rtsp stream there may be an fps value of zero. To prevent division by zero this lines are necessary. Static 0.2 is a suggestion.