### PR TITLE
Add onnx simplify support for dynamic onnx model in export.py.

### DIFF
--- a/export.py
+++ b/export.py
@@ -183,7 +183,9 @@ if __name__ == '__main__':
                 import onnxsim
 
                 print('\nStarting to simplify ONNX...')
-                onnx_model, check = onnxsim.simplify(onnx_model)
+                onnx_model, check = onnxsim.simplify(onnx_model,
+                                                     dynamic_input_shape=opt.dynamic,
+                                                     input_shapes={'images': list(img.shape)} if opt.dynamic else None)
                 assert check, 'assert check failed'
             except Exception as e:
                 print(f'Simplifier failure: {e}')


### PR DESCRIPTION
    Current export.py could not export an .onnx model with both --dynamic and --simplify tags, a warning will pop if you try to do so and tell you the simplification process failed.
    Inspired by u5 branch's export.py, I fixed this problem by giving more arguments when calling the onnxsim.simplify(). The method onnxsim.simplify() wants to take in an argument called 'dynamic_input_shape', and if you do not give one, it will set it to false by default. So, adding the argument 'dynamic_input_shape=opt.dynamic' will helps the onnxsim to know whether the given onxx model a dynamic model and simplify it correctly.