### PR TITLE
fixed to saving only images that have detections

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -139,8 +139,9 @@ def detect(save_img=False):
             # Save results (image with detections)
             if save_img:
                 if dataset.mode == 'image':
-                    cv2.imwrite(save_path, im0)
-                    print(f" The image with the result is saved in: {save_path}")
+                    if not len(pred[0]):  # if there are any detections for image    
+                        cv2.imwrite(save_path, im0)
+                        print(f" The image with the result is saved in: {save_path}")
                 else:  # 'video' or 'stream'
                     if vid_path != save_path:  # new video
                         vid_path = save_path


### PR DESCRIPTION
I found a bug with the following behavior while using detect.py for detection:

1. When the input directory contain no images with class instances, the script correctly did not save any of the images. (Correct behavior)
2. When the input directory contain at least one image with class instances (if there is at least one detection across all images in the directory), all the images are saved, even the ones without any detections in them. (Incorrect behavior)

In this pull request an in issue in 2. is treated. 
