### PR TITLE
Add small constant for kpt_loss_factor computation

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -147,7 +147,7 @@ class ComputeLoss:
                     #oks based loss
                     d = (pkpt_x-tkpt[i][:,0::2])**2 + (pkpt_y-tkpt[i][:,1::2])**2
                     s = torch.prod(tbox[i][:,-2:], dim=1, keepdim=True)
-                    kpt_loss_factor = (torch.sum(kpt_mask != 0) + torch.sum(kpt_mask == 0))/torch.sum(kpt_mask != 0)
+                    kpt_loss_factor = (torch.sum(kpt_mask != 0) + torch.sum(kpt_mask == 0))/(torch.sum(kpt_mask != 0) + 1e-9)
                     lkpt += kpt_loss_factor*((1 - torch.exp(-d/(s*(4*sigmas**2)+1e-9)))*kpt_mask).mean()
                 # Objectness
                 tobj[b, a, gj, gi] = (1.0 - self.gr) + self.gr * iou.detach().clamp(0).type(tobj.dtype)  # iou ratio


### PR DESCRIPTION
In the rare case where torch.sum(kpt_mask != 0) == 0 the kpt_loss_factor (leading to a nan loss) will go to infinity which is avoided by this small correction.