### PR TITLE
Correction of CPU/GPU indexes in Colab

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -682,7 +682,8 @@ class ComputeLossOTA:
                 all_gj.append(gj)
                 all_gi.append(gi)
                 all_anch.append(anch[i][idx])
-                from_which_layer.append(torch.ones(size=(len(b),)) * i)
+                from_which_layer.append((torch.ones(size=(len(b),)) * i).to('cuda'))
+                #from_which_layer.append(torch.ones(size=(len(b),)) * i)
                 
                 fg_pred = pi[b, a, gj, gi]                
                 p_obj.append(fg_pred[:, 4:5])
@@ -754,6 +755,7 @@ class ComputeLossOTA:
                 matching_matrix[:, anchor_matching_gt > 1] *= 0.0
                 matching_matrix[cost_argmin, anchor_matching_gt > 1] = 1.0
             fg_mask_inboxes = matching_matrix.sum(0) > 0.0
+            fg_mask_inboxes = fg_mask_inboxes.to(torch.device('cuda'))
             matched_gt_inds = matching_matrix[:, fg_mask_inboxes].argmax(0)
         
             from_which_layer = from_which_layer[fg_mask_inboxes]


### PR DESCRIPTION
Correct the following error in Colab about indexes:
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)