### PR TITLE
fixed the GPU indexing error when running in colab

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -682,8 +682,7 @@ class ComputeLossOTA:
                 all_gj.append(gj)
                 all_gi.append(gi)
                 all_anch.append(anch[i][idx])
-                from_which_layer.append(torch.ones(size=(len(b),)) * i)
-                
+                from_which_layer.append((torch.ones(size=(len(b),)) * i).to('cuda'))
                 fg_pred = pi[b, a, gj, gi]                
                 p_obj.append(fg_pred[:, 4:5])
                 p_cls.append(fg_pred[:, 5:])
@@ -754,7 +753,9 @@ class ComputeLossOTA:
                 matching_matrix[:, anchor_matching_gt > 1] *= 0.0
                 matching_matrix[cost_argmin, anchor_matching_gt > 1] = 1.0
             fg_mask_inboxes = matching_matrix.sum(0) > 0.0
+            fg_mask_inboxes = fg_mask_inboxes.to(torch.device('cuda'))
             matched_gt_inds = matching_matrix[:, fg_mask_inboxes].argmax(0)
+            
         
             from_which_layer = from_which_layer[fg_mask_inboxes]
             all_b = all_b[fg_mask_inboxes]


### PR DESCRIPTION
python train.py --workers 8 --device 0 --batch-size 16 --data data.yaml --img 640 640 --cfg cfg/training/yolov7.yaml --weights yolov7x.pt --name yolov7 --hyp data/hyp.scratch.p5.yaml

I got this error

RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)

I modified the loss.py file to automatically get the index of the default GPU selected using torch.device('cuda') function

fixes #1224 #1045 #1101 #1225