### PR TITLE
modify google_utils for latest release tag missing

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -23,6 +23,9 @@ def attempt_download(file, repo='WongKinYiu/yolov7'):
     if not file.exists():
         try:
             response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            if response['message'] == 'Not Found':
+                response = requests.get(f'https://api.github.com/repos/WongKinYiu/yolov7/releases').json()
+                response = requests.get(response[0]["url"]).json()
             assets = [x['name'] for x in response['assets']]  # release assets
             tag = response['tag_name']  # i.e. 'v1.0'
         except:  # fallback plan


### PR DESCRIPTION
When it was recently updated, latest tag release is missing. so, i think something wrong this repository manegement. this problem you just modify request url. but it'a stopgap.

Same Issue

#1205
#1184 
#1042 
#1024 
#1009 
#943 
#886 
#559 