### PR TITLE
Make error log more specific and easier to debug.

### DIFF
--- a/export.py
+++ b/export.py
@@ -14,7 +14,7 @@ from models.experimental import attempt_load, End2End
 from utils.activations import Hardswish, SiLU
 from utils.general import set_logging, check_img_size
 from utils.torch_utils import select_device
-from utils.add_nms import RegisterNMS
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -189,14 +189,18 @@ if __name__ == '__main__':
                 print(f'Simplifier failure: {e}')
 
         # print(onnx.helper.printable_graph(onnx_model.graph))  # print a human readable model
-        onnx.save(onnx_model,f)
+        onnx.save(onnx_model, f)
         print('ONNX export success, saved as %s' % f)
 
         if opt.include_nms:
-            print('Registering NMS plugin for ONNX...')
-            mo = RegisterNMS(f)
-            mo.register_nms()
-            mo.save(f)
+            try:
+                from utils.add_nms import RegisterNMS
+                print('Registering NMS plugin for ONNX...')
+                mo = RegisterNMS(f)
+                mo.register_nms()
+                mo.save(f)
+            except Exception as e:
+                print(f'Add NMS failure: {e}')
 
     except Exception as e:
         print('ONNX export failure: %s' % e)

--- a/utils/add_nms.py
+++ b/utils/add_nms.py
@@ -1,10 +1,8 @@
 import numpy as np
 import onnx
 from onnx import shape_inference
-try:
-    import onnx_graphsurgeon as gs
-except Exception as e:
-    print('Import onnx_graphsurgeon failure: %s' % e)
+import onnx_graphsurgeon as gs
+
 
 import logging
 


### PR DESCRIPTION
While exporting pytorch model to tensorrt with `--include-nms` flag, the error message is not clear enough that it only says "ONNX export failure: ...", but not mentioning "add nms failure", and leading some errors while using tensorrt engine like [this issue](https://github.com/WongKinYiu/yolov7/issues/1016).

Hence, I tried to make it more clear that if it fails to add nms layer in onnx model, it print log like "Add NMS failure: ...".

Hope this small change can help other developer to debug easier.