### PR TITLE
Fix coords clipping

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -335,10 +335,10 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):
 
 def clip_coords(boxes, img_shape):
     # Clip bounding xyxy bounding boxes to image shape (height, width)
-    boxes[:, 0].clamp_(0, img_shape[1])  # x1
-    boxes[:, 1].clamp_(0, img_shape[0])  # y1
-    boxes[:, 2].clamp_(0, img_shape[1])  # x2
-    boxes[:, 3].clamp_(0, img_shape[0])  # y2
+    boxes[:, 0].clamp_(0, img_shape[1] - 1)  # x1
+    boxes[:, 1].clamp_(0, img_shape[0] - 1)  # y1
+    boxes[:, 2].clamp_(0, img_shape[1] - 1)  # x2
+    boxes[:, 3].clamp_(0, img_shape[0] - 1)  # y2
 
 
 def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-7):


### PR DESCRIPTION
Coords have values from 0 to N-1 otherwise indexing image with these coords will lead to index error. 