### PR TITLE
edit to stop the circular import conflict,

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -6,8 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
-from . import general
-
 
 def fitness(x):
     # Model fitness as a weighted combination of metrics
@@ -109,7 +107,7 @@ def compute_ap(recall, precision, v5_metric=False):
 
     return ap, mpre, mrec
 
-
+from . import general
 class ConfusionMatrix:
     # Updated version of https://github.com/kaanakan/object_detection_confusion_matrix
     def __init__(self, nc, conf=0.25, iou_thres=0.45):


### PR DESCRIPTION
I made it so the line importing general.py would only be called right before it's needed, so if the metrics file is imported for one of the 3 functions above it the import would pass without needing to go back to general.py to solve the issue
at https://github.com/WongKinYiu/yolov7/issues/1306