### PR TITLE
Breaking Fix: Syntax error in loss.py

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -682,7 +682,7 @@ class ComputeLossOTA:
                 all_gj.append(gj)
                 all_gi.append(gi)
                 all_anch.append(anch[i][idx])
-                from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device)
+                from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device))
                 
                 fg_pred = pi[b, a, gj, gi]                
                 p_obj.append(fg_pred[:, 4:5])


### PR DESCRIPTION
Fixed missing bracket in up `utils/loss.py`

In last change
one `)` was missing in  `from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device)`