### PR TITLE
fix minor syntax error

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -682,7 +682,7 @@ class ComputeLossOTA:
                 all_gj.append(gj)
                 all_gi.append(gi)
                 all_anch.append(anch[i][idx])
-                from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device)
+                from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device))
                 
                 fg_pred = pi[b, a, gj, gi]                
                 p_obj.append(fg_pred[:, 4:5])


### PR DESCRIPTION
I was trying to use yolo7 manually and faced with a minor syntax error that required a fix in the original repo

```
Using device: cuda:0
Traceback (most recent call last):
  File "/home/alex/rnd/company/StrongSortTry/./main.py", line 82, in <module>
    main()
  File "/home/alex/rnd/company/StrongSortTry/./main.py", line 41, in main
    yolo_model = attempt_load(yolo_weights, map_location=device)
  File "/home/alex/rnd/company/StrongSortTry/yolov7/models/experimental.py", line 252, in attempt_load
    ckpt = torch.load(w, map_location=map_location)  # load
  File "/home/alex/rnd/company/StrongSortTry/venv/lib/python3.10/site-packages/torch/serialization.py", line 789, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "/home/alex/rnd/company/StrongSortTry/venv/lib/python3.10/site-packages/torch/serialization.py", line 1131, in _load
    result = unpickler.load()
  File "/home/alex/rnd/company/StrongSortTry/venv/lib/python3.10/site-packages/torch/serialization.py", line 1124, in find_class
    return super().find_class(mod_name, name)
  File "/home/alex/rnd/company/StrongSortTry/yolov7/models/yolo.py", line 15, in <module>
    from utils.loss import SigmoidBin
  File "/home/alex/rnd/company/StrongSortTry/yolov7/utils/loss.py", line 685
    from_which_layer.append((torch.ones(size=(len(b),)) * i).to(device)
                           ^
SyntaxError: '(' was never closed
```