### PR TITLE
added a simple Dockerfile that inherits the nvcr.io/nvidia/pytorch:21.08-py3 image

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM nvcr.io/nvidia/pytorch:21.08-py3
+
+RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
+RUN pip install seaborn thop
+
+#https://github.com/tensorflow/tensorboard/issues/5648
+#tensorboard not working on this nvidia docker img fix, you should uncomment the line below this one if your tensorboard doesnt work on this base image
+#RUN sed -i "s/\"--bind_all\", default=True,/\"--bind_all\",/g" /opt/conda/lib/python3.8/site-packages/tensorboard/plugins/core/core_plugin.py


### PR DESCRIPTION
Pretty self explanatory, the Dockerfile works so you don't have to rerun these commands every time you run a new container for whatever reason

apt update
apt install -y zip htop screen libgl1-mesa-glx
pip install seaborn thop

it is added to utils/docker, similair to the yolov5 repository
I leave it to the author to edit the readme.md installation part to tell people that a dockerfile exists now 