### PR TITLE
wandb Error on Kaggle

### DIFF
--- a/train.py
+++ b/train.py
@@ -489,7 +489,7 @@ def train(hyp, opt, device, tb_writer=None):
                 wandb_logger.log({"Results": [wandb_logger.wandb.Image(str(save_dir / f), caption=f) for f in files
                                               if (save_dir / f).exists()]})
         # Test best.pt
-        logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
+        logger.info('%g epochs completed in %.3f hours.\n' % (epochs - start_epoch + 1, (time.time() - t0) / 3600))
         if opt.data.endswith('coco.yaml') and nc == 80:  # if COCO
             for m in (last, best) if best.exists() else (last):  # speed, mAP tests
                 results, _, _ = test.test(opt.data,


### PR DESCRIPTION
When I ran it through Kaggle, it was giving an error on the line I was constantly changing. The `epoch` variable belongs to the for loop at the top, so there may be a problem. The `epochs` variable is public.