### PR TITLE
Fix: Endpoint error

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -22,7 +22,7 @@ def attempt_download(file, repo='WongKinYiu/yolov7'):
 
     if not file.exists():
         try:
-            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            response = requests.get(f'https://api.github.com/repos/{repo}/releases').json()[0]  # github api
             assets = [x['name'] for x in response['assets']]  # release assets
             tag = response['tag_name']  # i.e. 'v1.0'
         except:  # fallback plan


### PR DESCRIPTION
Using the Github API endpoint `https://api.github.com/repos/WongKinYiu/yolov7/releases/latest`, we receive the following response:

```json
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/reference/repos#get-the-latest-release"
}
```

This happens due to the fact that the current `release` is a `pre-release`. To fix this we just need to change the endpoint to `https://api.github.com/repos/WongKinYiu/yolov7/releases/`, making us able to retrieve every release and pre-release. Then, if we want the most recent one, we just need to access the array at position 0. 