### PR TITLE
fix numerical stability issues in half-precision

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -28,7 +28,7 @@ def detect(save_img=False):
     # Initialize
     set_logging()
     device = select_device(opt.device)
-    half = device.type != 'cpu'  # half precision only supported on CUDA
+    half = False # fix numerical stability issues in half-precision
 
     # Load model
     model = attempt_load(weights, map_location=device)  # load FP32 model


### PR DESCRIPTION
When using half = False (full-precision) for object detection on a GPU, you typically won't encounter numerical stability issues. This setting ensures that computations are performed with higher numerical precision, reducing the risk of instability during both training and inference. As a result, object detection on recorded videos is less likely to suffer from detection failures or inaccuracies caused by reduced precision. However, it's important to note that full-precision calculations may be slower and consume more GPU memory compared to half-precision, so the choice between the two options depends on your specific requirements and hardware capabilities.