### PR TITLE
Fix error when image mixup hyperparam is non-zero for instance segmentation training on u7

### DIFF
--- a/seg/utils/segment/augmentations.py
+++ b/seg/utils/segment/augmentations.py
@@ -18,7 +18,14 @@ def mixup(im, labels, segments, im2, labels2, segments2):
     r = np.random.beta(32.0, 32.0)  # mixup ratio, alpha=beta=32.0
     im = (im * r + im2 * (1 - r)).astype(np.uint8)
     labels = np.concatenate((labels, labels2), 0)
-    segments = np.concatenate((segments, segments2), 0)
+    # Handle cases if segments or segments2 is empty if no labels. It is a list if empty.
+    # TODO handle this issue upstream before ingestion of segments. This is a quick fix.
+    if isinstance(segments2, list):
+        return im, labels, segments
+    elif isinstance(segments, list):
+        return im, labels, segments2
+    else:
+        segments = np.concatenate((segments, segments2), 0)
     return im, labels, segments
 
 


### PR DESCRIPTION
Currently, if mixup is non-zero, an error is thrown in cases where there is an image with no labels. The following is the trace:

![image-2023-11-27-14-30-33-066](https://github.com/WongKinYiu/yolov7/assets/144819527/c93ff058-10d4-4a63-9854-d7de1c86fd0c)

Most current issues #795, https://github.com/laitathei/YOLOv7-Pytorch-Segmentation/issues/4 suggest to set [mixup to 0.0](https://github.com/WongKinYiu/yolov7/issues/795#issuecomment-1259752247) to fix it.

This is a more permanent fix.