### PR TITLE
Avoid massive memory leak

### DIFF
--- a/tools/keypoint.ipynb
+++ b/tools/keypoint.ipynb
@@ -58,7 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = non_max_suppression_kpt(output, 0.25, 0.65, nc=model.yaml['nc'], nkpt=model.yaml['nkpt'], kpt_label=True)\n",
+    "detached = output.detach()"
+    "output = non_max_suppression_kpt(detached, 0.25, 0.65, nc=model.yaml['nc'], nkpt=model.yaml['nkpt'], kpt_label=True)\n",
     "with torch.no_grad():\n",
     "    output = output_to_keypoint(output)\n",
     "nimg = image[0].permute(1, 2, 0) * 255\n",


### PR DESCRIPTION
Detaches output tensor so as to avoid huge memory leak when running for multiple images/videostream. https://github.com/WongKinYiu/yolov7/issues/941