### PR TITLE
fix: don't download file if already exists

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 import random
 import torch
 import torch.nn as nn
@@ -248,7 +249,8 @@ def attempt_load(weights, map_location=None):
     # Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
-        attempt_download(w)
+        if not os.path.isfile(w):
+            attempt_download(w)
         ckpt = torch.load(w, map_location=map_location)  # load
         model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
     


### PR DESCRIPTION
If one wants to export .pt model to another format multiple times (using different arguments), it makes absolutely no sense to download the .pt every time.