### PR TITLE
Fixed np.int issue in u7 branch and under the seg/utils/dataloader.py

### DIFF
--- a/seg/utils/dataloaders.py
+++ b/seg/utils/dataloaders.py
@@ -485,7 +485,7 @@ class LoadImagesAndLabels(Dataset):
         self.im_files = list(cache.keys())  # update
         self.label_files = img2label_paths(cache.keys())  # update
         n = len(shapes)  # number of images
-        bi = np.floor(np.arange(n) / batch_size).astype(np.int)  # batch index
+        bi = np.floor(np.arange(n) / batch_size).astype(np.int32)  # batch index
         nb = bi[-1] + 1  # number of batches
         self.batch = bi  # batch index of image
         self.n = n


### PR DESCRIPTION
 corrected model training bug by changing the data-type of the batch index(line 488)

This error occurs while training a custom dataset using the YOLOv7 segmentation module in a Colab environment. The issue is related to the numpy library, specifically an outdated use of np.int, which was deprecated starting in NumPy version 1.20.