### PR TITLE
Fix for torch 2.6

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -249,7 +249,7 @@ def attempt_load(weights, map_location=None):
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         attempt_download(w)
-        ckpt = torch.load(w, map_location=map_location)  # load
+        ckpt = torch.load(w, map_location=map_location, weights_only = False)  # load
         model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
     
     # Compatibility updates


### PR DESCRIPTION
In PyTorch 2.6, the default value of the weights_only argument in torch.load is changed from False to True.